### PR TITLE
Fix inclusion on some systems (notably Linux)

### DIFF
--- a/queue.h
+++ b/queue.h
@@ -35,7 +35,7 @@
 #ifndef	_SYS_QUEUE_H_
 #define	_SYS_QUEUE_H_
 
-#include <sys/_null.h>
+#define	NULL	((void *)0)
 
 /*
  * This file defines five types of data structures: singly-linked lists,


### PR DESCRIPTION
The included file is needed only for C++ compatibility.
You can verify this: https://web.mit.edu/freebsd/head/sys/sys/_null.h

Replacing the include with a simple define, solves compilation problems on many systems, notably Linux.